### PR TITLE
[HYDRAR-206] adding ability to pass on arguments to sparkr.session

### DIFF
--- a/R4ML/DESCRIPTION
+++ b/R4ML/DESCRIPTION
@@ -21,17 +21,17 @@ Suggests:
     devtools,
     roxygen2
 License: Apache License (== 2.0)
-Collate:
+Collate: 
     'zzz.R'
     'R4ML.R'
     'airline.R'
     'java.bridge.R'
-    'r4ml.env.R'
-    'util.commons.R'
     'r4ml.vector.R'
     'r4ml.frame.R'
     'r4ml.matrix.R'
     'r4ml.generic.R'
+    'r4ml.env.R'
+    'util.commons.R'
     'ml.model.base.R'
     'ml.model.als.R'
     'ml.model.cox.R'

--- a/R4ML/R/zzz.R
+++ b/R4ML/R/zzz.R
@@ -313,7 +313,7 @@ r4ml.session <- function(
   }
   
   # SparkR session init
-  sparkr.init <- function() {
+  sparkr.init <- function(...) {
     sc <- SparkR::sparkR.session(
       appName = "R4ML",
       sparkHome = sparkHome,
@@ -324,7 +324,7 @@ r4ml.session <- function(
     # spark context is now replace by sparkSession
     assign("sc", sc, envir = .GlobalEnv)
   }
-  sparkr.init()
+  sparkr.init(...)
   
   #sysml related initialization
   sysml.init()

--- a/R4ML/tests/testthat/test-zzz.R
+++ b/R4ML/tests/testthat/test-zzz.R
@@ -19,7 +19,7 @@ context("Testing zzz\n")
 
 # TODO add remaining zzz test
 
-test_that("r4ml.session", {
+test_that("r4ml.session.param.driver.memory", {
   # test if parameters passed to r4ml.session are propagated to sparkR session.
   r4ml.session.stop()
 
@@ -27,6 +27,18 @@ test_that("r4ml.session", {
   config <- sparkR.conf()
   expect_match(config$spark.driver.memory, "1G")
 
+  r4ml.session.stop()
+  r4ml.session()
+})
+
+test_that("r4ml.session.param.enableHiveSupport", {
+  # test if parameters passed to r4ml.session are propagated to sparkR session.
+  r4ml.session.stop()
+  
+  r4ml.session(enableHiveSuppor = FALSE)
+  config <- sparkR.conf()
+  expect_null(config$spark.sql.catalogImplementation)
+  
   r4ml.session.stop()
   r4ml.session()
 })

--- a/R4ML/tests/testthat/test-zzz.R
+++ b/R4ML/tests/testthat/test-zzz.R
@@ -31,7 +31,7 @@ test_that("r4ml.session.param.driver.memory", {
   r4ml.session()
 })
 
-test_that("r4ml.session.param.enableHiveSupport", {
+test_that("r4ml.session.param.enableHiveSupport.false", {
   # test if parameters passed to r4ml.session are propagated to sparkR session.
   r4ml.session.stop()
   
@@ -42,3 +42,16 @@ test_that("r4ml.session.param.enableHiveSupport", {
   r4ml.session.stop()
   r4ml.session()
 })
+
+test_that("r4ml.session.param.enableHiveSupport.true", {
+  # test if parameters passed to r4ml.session are propagated to sparkR session.
+  r4ml.session.stop()
+
+  r4ml.session(enableHiveSuppor = TRUE)
+  config <- sparkR.conf()
+  expect_match(config$spark.sql.catalogImplementation, "hive")
+
+  r4ml.session.stop()
+  r4ml.session()
+})
+

--- a/R4ML/tests/testthat/test-zzz.R
+++ b/R4ML/tests/testthat/test-zzz.R
@@ -1,0 +1,32 @@
+#
+# (C) Copyright IBM Corp. 2017
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+library(testthat)
+context("Testing zzz\n")
+
+# TODO add remaining zzz test
+
+test_that("r4ml.session", {
+  # test if parameters passed to r4ml.session are propagated to sparkR session.
+  r4ml.session.stop()
+
+  r4ml.session(sparkConfig = list("spark.driver.memory" = "1G"))
+  config <- sparkR.conf()
+  expect_match(config$spark.driver.memory, "1G")
+
+  r4ml.session.stop()
+  r4ml.session()
+})


### PR DESCRIPTION
This PR adds the ability to pass on arguments from r4ml.session to sparkr.session. This will allow user to set enableHiveSupport = FALSE. BTW, for sparkr.session, the defaults is enableHiveSupport = TRUE.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

