### PR TITLE
[R4ML-146] removing vector_ops examples

### DIFF
--- a/R4ML/R/r4ml.vector.R
+++ b/R4ML/R/r4ml.vector.R
@@ -30,25 +30,6 @@ setClassUnion("r4ml.frame.OrNull", c("r4ml.frame", "NULL"))
 #' @title r4ml.vector operations
 #' @rdname r4ml.vector_ops
 #' 
-#' @examples
-##'\dontrun{
-## TODO this test case is not working
-##' # Load the iris dataset as a r4ml.frame
-##' hf <- as.r4ml.frame(iris)
-##' 
-##' # Advanced nested arithmetic operations
-##' avgLength <- (hf$Sepal_Length + hf$Sepal_Width) / 2
-##' ones <- sin(avgLength) ^ 2 + cos(avgLength ^ 2)
-##' show(ones)
-##' 
-##' # Character operations
-##' lower(substr(hf$Species, 1, 3))
-##' 
-##' # Recoding columns
-##' hf$size <- ifelse(avgLength > 4, "large", "small")
-##' str(hf)
-##' }
-NULL
 #' @export
 setClass("r4ml.vector", 
          slots = list(hf = "r4ml.frame.OrNull"),


### PR DESCRIPTION
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

r4ml.vector operations are not available, but SparkDataFrame operations can be accessed...an example of addition is shown here:
df$newCol = df$Sepal_Length + df$Sepal_Width
