### PR TITLE
[R4ML-196] fixing step.lm when intercept = TRUE

### DIFF
--- a/R4ML/inst/sysml/scripts/algorithms/StepLinearRegDS.dml
+++ b/R4ML/inst/sysml/scripts/algorithms/StepLinearRegDS.dml
@@ -233,8 +233,7 @@ if (dir == "forward") {
   
   Selected = columns_fixed_ordered;
   if (intercept_status != 0) {
-    maxS = max(Selected)
-    Selected = cbind(Selected, matrix(maxS + 1, rows=1, cols=1))
+    Selected = cbind(Selected, matrix(boa_ncol, rows=1, cols=1))
   }
 
   beta_out = reorder_matrix(boa_ncol, beta_out, Selected);

--- a/R4ML/inst/sysml/scripts/algorithms/StepLinearRegDS.dml
+++ b/R4ML/inst/sysml/scripts/algorithms/StepLinearRegDS.dml
@@ -232,8 +232,12 @@ if (dir == "forward") {
   [AIC, beta_out] = linear_regression (X_global, y, m_orig, columns_fixed_ordered, fileB, 1.0);
   
   Selected = columns_fixed_ordered;
+  if (intercept_status != 0) {
+    maxS = max(Selected)
+    Selected = cbind(Selected, matrix(maxS + 1, rows=1, cols=1))
+  }
 
-  beta_out = reorder_matrix(X_orig, beta_out, Selected);
+  beta_out = reorder_matrix(boa_ncol, beta_out, Selected);
 
   write(Selected, fileS, format=fmt);
   write(beta_out, fileB, format=fmt);
@@ -435,13 +439,13 @@ linear_regression = function (Matrix[Double] X, Matrix[Double] y, Double m_orig,
 
 
 reorder_matrix = function(
-  matrix[double] X, # the input matrix, we have to account for extra beta0 for the intercept
+  double ncolX, # number of column in X, inlcuding the intercept column
   matrix[double] B, # beta
   matrix[double] S  # Selected
 ) return (matrix[double] Y) {
   
   S = t(S);
-  num_empty_B = ncol(X) - nrow(B);
+  num_empty_B = ncolX - nrow(B);
   if (num_empty_B < 0) {
     stop("Error: unable to re-order the matrix. Reason: B more than matrix X");
   }
@@ -461,9 +465,13 @@ reorder_matrix = function(
   # since the table won't accept zeros as index we hack it.
 
   S_xo = replace(target = S_x, pattern = 0, replacement = nrow(S_x));
-
-  P = table(seq(1, nrow(S_xo)), S_xo, ncol(X), ncol(X));
-  Y = P;
+  # TODO this is a hack to avoid a bug in the optimizer where it removes
+  # the last few rows of matrix P, See jira SYSTEMML-1467. This bug is fixed
+  # in SystemML. We need to remove this if statement when we move to newer
+  # version of SystemML.
+  seqS_xo = seq(1, nrow(S_xo));
+  if(1==1) {}
+  P = table(seqS_xo, S_xo, ncolX, ncolX);
 
   Y = t(P) %*% B_x;
 }

--- a/R4ML/inst/sysml/scripts/algorithms/StepLinearRegDS.dml
+++ b/R4ML/inst/sysml/scripts/algorithms/StepLinearRegDS.dml
@@ -249,7 +249,7 @@ if (dir == "forward") {
 # It also outputs the AIC of the computed model.
 
 linear_regression = function (Matrix[Double] X, Matrix[Double] y, Double m_orig, Matrix[Double] Selected, String fileB, Double writeStats)
-  return (Double AIC, Matrix[Double] beta_out) {
+  return (Double AIC, Matrix[Double] beta) {
 
     intercept_status = ifdef ($icpt, 0);
     fmt = ifdef ($fmt, "text");
@@ -368,71 +368,6 @@ linear_regression = function (Matrix[Double] X, Matrix[Double] y, Double m_orig,
         print (str);
         print ("");
       }
-
-      # Prepare the output matrix
-      print ("Writing the output matrix...");
-      if (intercept_status == 2) {
-        beta_out = append (beta, beta_unscaled);
-      } else {
-        beta_out = beta;
-      }
-      
-      no_selected = ncol (Selected);
-      
-      max_selected = max (Selected);
-      last = max_selected + 1;
-
-      if (intercept_status != 0) {
-
-        Selected_ext = append (Selected, as.matrix (last));
-        
-        P1 = table (seq (1, ncol (Selected_ext)), t(Selected_ext)); 
-        
-        if (intercept_status == 2) {
-          P1_beta = P1 * beta;
-          P2_beta = colSums (P1_beta);
-          P1_beta_unscaled = P1 * beta_unscaled;
-          P2_beta_unscaled = colSums(P1_beta_unscaled);
-          
-          if (max_selected < m_orig) {
-            P2_beta = append (P2_beta, matrix (0, rows=1, cols=(m_orig - max_selected)));
-            P2_beta_unscaled = append (P2_beta_unscaled, matrix (0, rows=1, cols=(m_orig - max_selected)));
-            
-            P2_beta[1, m_orig+1] = P2_beta[1, max_selected + 1];
-            P2_beta[1, max_selected + 1] = 0;
-            
-            P2_beta_unscaled[1, m_orig+1] = P2_beta_unscaled[1, max_selected + 1];
-            P2_beta_unscaled[1, max_selected + 1] = 0;
-          }
-          
-          beta_out = append (t(P2_beta), t(P2_beta_unscaled));
-          
-        } else {
-          P1_beta = P1 * beta;
-          P2_beta = colSums (P1_beta);
-          
-          if (max_selected < m_orig) {
-            P2_beta = append (P2_beta, matrix (0, rows=1, cols=(m_orig - max_selected)));
-            P2_beta[1, m_orig+1] = P2_beta[1, max_selected + 1];
-            P2_beta[1, max_selected + 1] = 0;
-          }
-          beta_out = t(P2_beta);
-        }
-      } else {
-
-        P1 = table (seq (1, no_selected), t(Selected));
-
-        P1_beta = P1 * beta;
-
-        P2_beta = colSums (P1_beta);
-
-        if (max_selected < m_orig) {
-          P2_beta = append (P2_beta, matrix (0, rows=1, cols=(m_orig - max_selected)));
-        }
-
-        beta_out = t(P2_beta);
-
-      }
     }
   }
 
@@ -442,35 +377,31 @@ reorder_matrix = function(
   matrix[double] B, # beta
   matrix[double] S  # Selected
 ) return (matrix[double] Y) {
+  # This function assumes that B and S have same number of elements.
+  # if the intercept is included in the model, all inputs should be adjusted
+  # appropriately before calling this function.
   
   S = t(S);
   num_empty_B = ncolX - nrow(B);
   if (num_empty_B < 0) {
     stop("Error: unable to re-order the matrix. Reason: B more than matrix X");
   }
-  # +1 since extra column is for dummy r,c  
-  B_x = B;
-  S_x = S;
+
   if (num_empty_B > 0) {
-
-    zero_B_n = matrix(0, rows = num_empty_B, cols=1);
-    zero_m_n = matrix(0, rows = num_empty_B + 1, cols=1);
-
-    B_x = rbind(B, zero_B_n);
-
-    S_x = rbind(S, zero_m_n); # S is now full rank as X
+    pad_zeros = matrix(0, rows = num_empty_B, cols=1);
+    B = rbind(B, pad_zeros);
+    S = rbind(S, pad_zeros);
   }
 
   # since the table won't accept zeros as index we hack it.
-
-  S_xo = replace(target = S_x, pattern = 0, replacement = nrow(S_x));
+  S0 = replace(target = S, pattern = 0, replacement = ncolX+1);
   # TODO this is a hack to avoid a bug in the optimizer where it removes
   # the last few rows of matrix P, See jira SYSTEMML-1467. This bug is fixed
   # in SystemML. We need to remove this if statement when we move to newer
   # version of SystemML.
-  seqS_xo = seq(1, nrow(S_xo));
+  seqS = seq(1, nrow(S0));
   if(1==1) {}
-  P = table(seqS_xo, S_xo, ncolX, ncolX);
+  P = table(seqS, S0, ncolX, ncolX);
 
-  Y = t(P) %*% B_x;
+  Y = t(P) %*% B;
 }

--- a/R4ML/tests/testthat/test-ml.model.step.lm.R
+++ b/R4ML/tests/testthat/test-ml.model.step.lm.R
@@ -25,6 +25,15 @@ test_that("r4ml.step.lm direct", {
   stats(step_lm)
 })
 
+test_that("r4ml.step.lm with intercept", {
+  data("iris")
+
+  r4ml_iris <- as.r4ml.matrix(iris[, -5])
+  step_lm <- r4ml.step.lm(Sepal_Length ~ ., data = r4ml_iris, intercept = TRUE)
+  coef(step_lm)
+  stats(step_lm)
+})
+
 test_that("r4ml.step.lm predict", {
   df <- iris
   df$Species <- (as.numeric(df$Species))


### PR DESCRIPTION
fixing the issue where the steplm breaks when intercept is included in the model



Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

