### PR TITLE
[HYDRAR-115] adding accuracy tests for coefficients from step.lm

### DIFF
--- a/R4ML/tests/testthat/test-ml.model.step.lm.R
+++ b/R4ML/tests/testthat/test-ml.model.step.lm.R
@@ -69,3 +69,43 @@ test_that("r4ml.step.lm predict_scoring", {
 })
 
 # TODO add the shiftAndScale test in future when intercept=2 is added
+
+test_that("r4ml.step.lm coefficients without intercept", {
+  df <- mtcars
+  r.slm <- step(lm(mpg ~ -1, data = df),
+                mpg ~ cyl + disp + hp + drat + wt + qsec + vs + am + gear + carb,
+                direction = "forward")
+  
+  df.r4ml <- as.r4ml.matrix(as.r4ml.frame(df))
+  r4ml.slm <- r4ml.step.lm(mpg ~ ., data = df.r4ml, intercept = FALSE)
+  
+  # coefficients from step() and r4ml.step.lm() are not in the same order
+  # So, we'll sort the coefficients by name for both models before comparison
+  snames <- sort(names(coef(r.slm)))
+
+  betas1 <- coef(r4ml.slm)[snames,]
+  betas2 <- coef(r.slm)[snames]
+  names(betas2) <- NULL
+
+  expect_equal(betas1, betas2)
+})
+
+test_that("r4ml.step.lm coefficients without intercept", {
+  df <- mtcars
+  r.slm <- step(lm(mpg ~ 1, data = df),
+                mpg ~ cyl + disp + hp + drat + wt + qsec + vs + am + gear + carb,
+                direction = "forward")
+  
+  df.r4ml <- as.r4ml.matrix(as.r4ml.frame(df))
+  r4ml.slm <- r4ml.step.lm(mpg ~ ., data = df.r4ml, intercept = TRUE)
+  
+  # coefficients from step() and r4ml.step.lm() are not in the same order
+  # So, we'll sort the coefficients by name for both models before comparison
+  snames <- sort(names(coef(r.slm)))
+  
+  betas1 <- coef(r4ml.slm)[snames,]
+  betas2 <- coef(r.slm)[snames]
+  names(betas2) <- NULL
+  
+  expect_equal(betas1, betas2)
+})

--- a/R4ML/tests/testthat/test-ml.model.step.lm.R
+++ b/R4ML/tests/testthat/test-ml.model.step.lm.R
@@ -90,7 +90,7 @@ test_that("r4ml.step.lm coefficients without intercept", {
   expect_equal(betas1, betas2)
 })
 
-test_that("r4ml.step.lm coefficients without intercept", {
+test_that("r4ml.step.lm coefficients with intercept", {
   df <- mtcars
   r.slm <- step(lm(mpg ~ 1, data = df),
                 mpg ~ cyl + disp + hp + drat + wt + qsec + vs + am + gear + carb,


### PR DESCRIPTION
Adding tests for coefficients from step.lm with/without intercept, comparing the results with step() from R.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

