### PR TITLE
[R4ML-243] fixing the problem with 0 or negative integer class label

### DIFF
--- a/R4ML/inst/sysml/scripts/algorithms/MultiLogReg.dml
+++ b/R4ML/inst/sysml/scripts/algorithms/MultiLogReg.dml
@@ -143,7 +143,7 @@ if (intercept_status == 2)  # scale-&-shift X columns to mean 0, variance 1
 if (min (Y_vec) <= 0) { 
     # Category labels "0", "-1" etc. are converted into the largest label
     max_y = max (Y_vec);
-    Y_vec  = Y_vec  + (- Y_vec  + max_y + 1) * Y_vec <= 0.0;
+    Y_vec  = Y_vec  + (- Y_vec  + max_y + 1) * (Y_vec <= 0.0);
 }
 Y = table (seq (1, N, 1), Y_vec);
 K = ncol (Y) - 1;   # The number of  non-baseline categories


### PR DESCRIPTION
This PR fixes the mlogit failure due to 0 or negative class labels. The but was introduced when ppred function was removed.


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

