### PR TITLE
Go from SparkDataFrame directly to systemml matrix (update to [R4ML-247])

### DIFF
--- a/R4ML/R/sysml.bridge.R
+++ b/R4ML/R/sysml.bridge.R
@@ -372,9 +372,7 @@ sysml.RDDConverterUtils <- setRefClass("sysml.RDDConverterUtils",
           SparkR:::newJObject("org.apache.spark.api.java.JavaSparkContext",
                               sparkContext)
 
-      # Functionality has moved to a different class in SystemML 0.13+
-      #env$jclass <<- "org.apache.sysml.runtime.instructions.spark.utils.RDDConverterUtilsExt"
-      env$jclass <<- "org.apache.sysml.runtime.instructions.spark.utils.FrameRDDConverterUtils"
+      env$jclass <<- "org.apache.sysml.runtime.instructions.spark.utils.RDDConverterUtils"
     },
 
     finalize = function() {
@@ -411,7 +409,7 @@ sysml.RDDConverterUtils <- setRefClass("sysml.RDDConverterUtils",
       vdf
     },
 
-    dataFrameToBinaryBlock = function(df, mc, id = FALSE) {
+    dataFrameToBinaryBlock = function(df, mc, id = FALSE, isVector = FALSE) {
       '\\tabular{ll}{
         Description:\\tab \\cr
         \\tab convert the spark dataframe to systemML binary block.\\cr
@@ -420,13 +418,8 @@ sysml.RDDConverterUtils <- setRefClass("sysml.RDDConverterUtils",
       stopifnot(class(df) == "r4ml.matrix",
                 class(mc) == "sysml.MatrixCharacteristics")
       fname <- "dataFrameToBinaryBlock"
-      # Conversion happens in two phases: DataFrame --> Frame --> Matrix
-      bin_block_rdd_jref<-SparkR:::callJStatic(env$jclass, fname, env$javaSparkContext, df@sdf, mc$env$jref, id)
-      vdf_jref<-SparkR:::callJStatic(env$jclass, "binaryBlockToMatrixBlock", bin_block_rdd_jref, mc$env$jref, mc$env$jref)
-      vdf_jref
-      # @NOTE causing issues so remove it and hack around
-      # vdf <- SparkR:::RDD(vdf_jref)
-      # vdf
+      bin_block_rdd_jref<-SparkR:::callJStatic(env$jclass, fname, env$javaSparkContext, df@sdf, mc$env$jref, id, isVector)
+      return(bin_block_rdd_jref)
     }
   )
 )

--- a/R4ML/R/sysml.bridge.R
+++ b/R4ML/R/sysml.bridge.R
@@ -418,8 +418,8 @@ sysml.RDDConverterUtils <- setRefClass("sysml.RDDConverterUtils",
       stopifnot(class(df) == "r4ml.matrix",
                 class(mc) == "sysml.MatrixCharacteristics")
       fname <- "dataFrameToBinaryBlock"
-      bin_block_rdd_jref<-SparkR:::callJStatic(env$jclass, fname, env$javaSparkContext, df@sdf, mc$env$jref, id, isVector)
-      return(bin_block_rdd_jref)
+      vdf_jref <- SparkR::sparkR.callJStatic(env$jclass, fname, env$javaSparkContext, df@sdf, mc$env$jref, id, isVector)
+      return(vdf_jref)
     }
   )
 )


### PR DESCRIPTION
This PR changes the way we convert a SparkDataFrame to a SystemML matrix and when combined with #36 it should provide a significant performance improvement.

Thanks @dusenberrymw for all your help with this PR!