### PR TITLE
preprocess omit.na bug

### DIFF
--- a/R4ML/R/ml.preprocess.R
+++ b/R4ML/R/ml.preprocess.R
@@ -267,6 +267,12 @@ r4ml.ml.preprocess <- function(
       data <- as.r4ml.frame(data, repartition = FALSE)
     }
 
+    if (r4ml.is.empty.df(data)) {
+      r4ml.warn(logSource, "omit.na resulted in a dataset containing 0 records")
+      r4ml.warn(logSource, "Make sure your dataset contains at least one valid records")
+      stop_now <<- TRUE
+    }
+    
     metadata <- list()
     return(list(data = data, metadata = metadata))
   }

--- a/R4ML/R/ml.preprocess.R
+++ b/R4ML/R/ml.preprocess.R
@@ -258,27 +258,17 @@ r4ml.ml.preprocess <- function(
   # 6. we apply one hot encoding
   #1.
   
-  
-  is.omit.na <- !missing(omit.na)
-  
   # variable to control the next stop of ml.preprocessors
   stop_now <- FALSE
   proxy.omit.na <- function(data) {
-    r4ml_df = data
-    if (is.omit.na) {
-      r4ml_df <- as.r4ml.frame(SparkR::dropna(data, cols = omit.na), repartition = FALSE)
-      if (!r4ml_df@env$isCached) {
-        ignore <- SparkR::cache(r4ml_df)
-      }
-      cnt <- SparkR::count(r4ml_df)
-      if (cnt == 0) {
-        r4ml.warn(logSource, "After na omission, there are no records left")
-        r4ml.warn(logSource, "Make sure that you dataset contains atleast one valid records")
-        stop_now <<- TRUE
-      }
+    
+    if (!is.null(omit.na)) {
+      data <- SparkR::dropna(data, cols = omit.na)
+      data <- as.r4ml.frame(data, repartition = FALSE)
     }
+
     metadata <- list()
-    list(data=r4ml_df, metadata=metadata)
+    return(list(data = data, metadata = metadata))
   }
   #2.
   proxy.impute <- function(data) {

--- a/R4ML/R/util.io.R
+++ b/R4ML/R/util.io.R
@@ -699,3 +699,7 @@ HadoopFS <- R6::R6Class(
   )
 )
 
+r4ml.is.empty.df <- function(data) {
+  # returns TRUE if `data` contains 0 rows
+  return(is.null(SparkR::first(data)[1, 1][[1]]))
+}

--- a/R4ML/tests/testthat/test-ml.preprocess.R
+++ b/R4ML/tests/testthat/test-ml.preprocess.R
@@ -52,12 +52,29 @@ test_that("r4ml.ml.preprocess omit.na", {
   iris_hf$Petal.Width[5] <- NA
   iris_hf <- as.r4ml.frame(iris_hf)
   
+  # with omit.na col specified
   iris_transform <- r4ml.ml.preprocess(
-    iris_hf,
+    data = iris_hf,
     transformPath = tempdir(),
     omit.na = c("Petal_Width")
   )
   expect_equal(nrow(iris_transform$data), 149)
+  
+  # with no cols specified (should default to all columns)
+  iris_transform <- r4ml.ml.preprocess(
+    data = iris_hf,
+    transformPath = tempdir()
+  )
+  expect_equal(nrow(iris_transform$data), 149)
+  
+  # with no cols spefied
+  iris_transform <- r4ml.ml.preprocess(
+    data = iris_hf,
+    transformPath = tempdir(),
+    omit.na = c()
+  )
+  expect_equal(nrow(iris_transform$data), 150)
+  
 })
 
 #Execute ml.preprocess without transformPath parameter

--- a/R4ML/tests/testthat/test-util.io.R
+++ b/R4ML/tests/testthat/test-util.io.R
@@ -177,3 +177,14 @@ test_that("HadoopFS", {
   user_home <- hfs$user.home()
 })
 
+test_that("r4ml.is.empty.df", {
+  df <- SparkR::as.DataFrame(datasets::iris)
+  expect_false(r4ml.is.empty.df(df))
+  
+  df <- datasets::iris
+  df$Species <- NA
+  df <- SparkR::as.DataFrame(df)
+  df <- SparkR::dropna(df)
+  expect_true(r4ml.is.empty.df(df))
+})
+


### PR DESCRIPTION
This fixes issue #46 where the `omit.na` argument to `r4ml.ml.preprocess` doesn't always work as expected. I also added additional test cases to make sure we don't run into this issue again in the future.